### PR TITLE
add bush config file for jaxon_blue

### DIFF
--- a/hrpsys_choreonoid/config/JAXON_BLUECustomizer.yaml
+++ b/hrpsys_choreonoid/config/JAXON_BLUECustomizer.yaml
@@ -1,0 +1,11 @@
+bush:
+  springT: 7.5e5
+  dampingT: 2.5e3
+  springR: 2.5e3
+  dampingR: 4.0
+
+tilt_laser:
+  TILT_UPPER_BOUND: 1.35
+  TILT_POSITIVE_SPEED: 1.0
+  TILT_LOWER_BOUND: -0.7
+  TILT_NEGATIVE_SPEED: -1.0

--- a/hrpsys_choreonoid_tutorials/launch/jaxon_blue_choreonoid.launch
+++ b/hrpsys_choreonoid_tutorials/launch/jaxon_blue_choreonoid.launch
@@ -47,6 +47,8 @@
        value="$(find hrpsys_ros_bridge_tutorials)/models/JAXON_BLUE_controller_config.yaml" />
   <arg name="CONNECT_CONSTRAINT_FORCE_LOGGER_PORTS" default="false"/>
 
+  <env name="CUSTOMIZER_CONF_FILE" value="$(find hrpsys_choreonoid)/config/JAXON_BLUECustomizer.yaml" />
+
   <!-- hrpsys -->
   <include file="$(find hrpsys_choreonoid)/launch/startup_choreonoid.launch" >
     <!-- robot dependant settings -->


### PR DESCRIPTION
choreonoidのシミュレーションでのブッシュの剛性とダンピングを調整し，ZMPが振動しないようにした

fz（調整前）
![force_before-tuning](https://user-images.githubusercontent.com/6716207/116783752-7ef4fd80-aacb-11eb-9686-9b2f23a225cc.png)
fz（調整後）
![force_after-tuning](https://user-images.githubusercontent.com/6716207/116783759-887e6580-aacb-11eb-933f-1aad4be64cc2.png)

ZMP（調整前）
![zmp_before-tuning](https://user-images.githubusercontent.com/6716207/116783763-8e744680-aacb-11eb-8212-c04e15015efc.png)
ZMP（調整後）
![zmp_after-tuning](https://user-images.githubusercontent.com/6716207/116783764-90d6a080-aacb-11eb-9dd6-cc4b3c88266d.png)
